### PR TITLE
Feat: Implement in-memory accessToken with HttpOnly refreshToken for …

### DIFF
--- a/kriptees-backend/utils/JwtToken.js
+++ b/kriptees-backend/utils/JwtToken.js
@@ -12,16 +12,8 @@ const sendJWtToken = (user, statusCode, res) => {
     maxAge: process.env.COOKIE_EXPIRE * 24 * 60 * 60 * 1000, // days to ms
   });
 
-  // Send Access Token in HttpOnly Cookie
-  res.cookie("accessToken", accessToken, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: "lax",
-    path: "/", // allow across the app
-    maxAge: 15 * 60 * 1000, // 15 minutes
-  });
-
-  // Send user and accessToken (optional) in response body for Redux
+  // Send user and accessToken in the response body for Redux
+  // Access token is NOT sent as a cookie
   res.status(statusCode).json({
     success: true,
     accessToken,

--- a/kriptees-frontend/src/actions/blogActions.js
+++ b/kriptees-frontend/src/actions/blogActions.js
@@ -18,6 +18,7 @@ import {
   CLEAR_BLOG_ERRORS,
   CLEAR_BLOG_MESSAGE,
 } from "../constants/blogConstants";
+import { getAccessToken } from "../utils/auth"; // Corrected import
 
 const API_BASE = "http://localhost:5000/api/v1";
 
@@ -26,11 +27,10 @@ export const createBlogPost = (postData) => async (dispatch) => {
   try {
     dispatch({ type: CREATE_BLOG_POST_REQUEST });
 
-    const token = localStorage.getItem("token");
     const config = {
       headers: {
         "Content-Type": "application/json",
-        Authorization: token, 
+        Authorization: `Bearer ${getAccessToken()}`,
       },
       withCredentials: true,
     };
@@ -96,11 +96,10 @@ export const updateBlogPost = (postId, postData) => async (dispatch) => {
   try {
     dispatch({ type: UPDATE_BLOG_POST_REQUEST });
 
-    const token = localStorage.getItem("token");
     const config = {
       headers: {
         "Content-Type": "application/json",
-        Authorization: token,
+        Authorization: `Bearer ${getAccessToken()}`,
       },
       withCredentials: true,
     };
@@ -124,10 +123,9 @@ export const deleteBlogPost = (postId) => async (dispatch) => {
   try {
     dispatch({ type: DELETE_BLOG_POST_REQUEST });
 
-    const token = localStorage.getItem("token");
     const config = {
       headers: {
-        Authorization: token,
+        Authorization: `Bearer ${getAccessToken()}`,
       },
       withCredentials: true,
     };

--- a/kriptees-frontend/src/utils/auth.js
+++ b/kriptees-frontend/src/utils/auth.js
@@ -7,3 +7,7 @@ export function setAccessToken(token) {
 export function getAccessToken() {
   return accessToken;
 }
+
+export function removeAccessToken() {
+  accessToken = ""; // Or set to null, depending on preference
+}


### PR DESCRIPTION
…persistence

- Backend: Ensures accessToken is only in JSON response, refreshToken in HttpOnly cookie.
- Frontend: Manages accessToken in JavaScript memory.
- Frontend: `load_UserProfile` action now handles token refresh on app load using the refreshToken cookie to persist login across page refreshes.
- Frontend: Updated `logout` to clear in-memory token and session data.
- Frontend: Corrected `blogActions.js` to use in-memory token for auth headers.